### PR TITLE
added include to make it work on Ubuntu

### DIFF
--- a/include/cinolib/io/read_OBJ.cpp
+++ b/include/cinolib/io/read_OBJ.cpp
@@ -48,6 +48,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <string.h>
 #include <assert.h>
 
 namespace cinolib


### PR DESCRIPTION
Error - line 167:

> ‘strdup’ was not declared in this scope; did you mean ‘strdupa’?
>   167 |                     read_point_id(strdup(sub_str.c_str()), v_pos, v_tex, v_nor); 