### PR TITLE
Update main.cpp

### DIFF
--- a/examples/01_base_app_trimesh/main.cpp
+++ b/examples/01_base_app_trimesh/main.cpp
@@ -1,11 +1,9 @@
 /* This is a base application for cinolib (https://github.com/maxicino/cinolib).
  * It will show a GL canvas (and associated control panel) to interact
  * with a triangle mesh.
- *
  * In case you don't need a GUI, you can drop the "Drawable" prefix from the mesh data type.
  * What you will get is a lighter yet fully operational mesh data structure, just
  * without the burden of OpenGL code necessary for rendering!
- *
  * Enjoy!
 */
 
@@ -15,6 +13,7 @@
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
+#define DRAW_MESH TRUE
 int main(int argc, char **argv)
 {
     using namespace cinolib;
@@ -23,6 +22,8 @@ int main(int argc, char **argv)
 
     std::string s = (argc==2) ? std::string(argv[1]) : std::string(DATA_PATH) + "/bunny.obj";
 
+    #ifdef DRAW_MESH
+    
     DrawableTrimesh<> m(s.c_str());
 
     GLcanvas gui;
@@ -32,6 +33,13 @@ int main(int argc, char **argv)
     // CMD+1 to show mesh controls.
     SurfaceMeshControlPanel<DrawableTrimesh<>> panel(&m, &gui);
     QApplication::connect(new QShortcut(QKeySequence(Qt::CTRL+Qt::Key_1), &gui), &QShortcut::activated, [&](){panel.show();});
+    
+    #else
+    Trimesh<> m(s.c_str());
+     
+    // Your model processing code goes here:
+    
+    #endif
 
     return a.exec();
 }


### PR DESCRIPTION
Conditional inclusion progr. technique application proposal to illustrate "* In case you don't need a GUI, you can drop the "Drawable" prefix from the mesh data type.
 * What you will get is a lighter yet fully operational mesh data structure, just
 * without the burden of OpenGL code necessary for rendering!" in code(make it more clear).