### PR TITLE
Polygon Kernel fix

### DIFF
--- a/include/cinolib/polygon_kernel.cpp
+++ b/include/cinolib/polygon_kernel.cpp
@@ -35,6 +35,7 @@
 *********************************************************************************/
 #include <cinolib/polygon_kernel.h>
 #include <cinolib/min_max_inf.h>
+#include <cinolib/geometry/polygon_utils.h>
 
 #ifdef CINOLIB_USES_BOOST
 #include <boost/geometry/geometries/polygon.hpp>
@@ -54,6 +55,9 @@ double polygon_kernel(const std::vector<vec3d> & poly,   // will discard z compo
 {
     std::vector<vec2d> poly_2d, kernel_2d;
     for(auto p : poly) poly_2d.push_back(vec2d(p));
+
+    if (!polygon_is_CCW(poly_2d))
+        std::reverse(poly_2d.begin(), poly_2d.end());
 
     double area = polygon_kernel(poly_2d, kernel_2d);
 

--- a/include/cinolib/polygon_kernel.cpp
+++ b/include/cinolib/polygon_kernel.cpp
@@ -56,12 +56,9 @@ double polygon_kernel(const std::vector<vec3d> & poly,   // will discard z compo
     std::vector<vec2d> poly_2d, kernel_2d;
     for(auto p : poly) poly_2d.push_back(vec2d(p));
 
-    if (!polygon_is_CCW(poly_2d))
-        std::reverse(poly_2d.begin(), poly_2d.end());
-
     double area = polygon_kernel(poly_2d, kernel_2d);
 
-    if (area > 0)
+    if(area > 0)
     {
         kernel.clear();
         for(auto p : kernel_2d) kernel.push_back(vec3d(p.x(), p.y(), 0));
@@ -79,8 +76,10 @@ double polygon_kernel(const std::vector<vec2d> & poly,
                             std::vector<vec2d> & kernel)
 {
     kernel.clear();
-    if (poly.empty()) return 0;
+    if(poly.empty()) return 0;
 
+    if(!polygon_is_CCW(poly)) std::reverse(poly.begin(), poly.end());
+  
     // define 2d axis aligned bbox
     vec2d min( inf_double,  inf_double);
     vec2d max(-inf_double, -inf_double);


### PR DESCRIPTION
This is to enable the possibility to compute polygon kernel if the input is not CCW-oriented. The fix is implemented for polygons embedded into a 3D space, but it should be done for 2D spaces. 