### PR TITLE
fix compilation issues on VS2019 16.8.5

### DIFF
--- a/include/cinolib/meshes/abstract_polygonmesh.cpp
+++ b/include/cinolib/meshes/abstract_polygonmesh.cpp
@@ -1784,7 +1784,7 @@ CINO_INLINE
 void AbstractPolygonMesh<M,V,E,P>::poly_export_element(const uint pid, std::vector<vec3d> & verts, std::vector<std::vector<uint>> & faces) const
 {
     std::vector<uint> f(this->verts_per_poly(pid));
-    std::iota(f.begin(), f.end(), verts.size());
+    std::iota(f.begin(), f.end(), static_cast<uint>(verts.size()));
     for(uint vid : adj_p2v(pid)) verts.push_back(this->vert(vid));
     faces.push_back(f);
 }

--- a/include/cinolib/meshes/mesh_attributes.h
+++ b/include/cinolib/meshes/mesh_attributes.h
@@ -122,17 +122,16 @@ enum
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-typedef struct
+struct Mesh_std_attributes
 {
     std::string filename;
     bool        update_normals = true;
     bool        update_bbox    = true;
-}
-Mesh_std_attributes;
+};
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-typedef struct
+struct Vert_std_attributes
 {
     vec3d          normal  = vec3d(0,0,0);
     Color          color   = Color::WHITE();
@@ -140,22 +139,20 @@ typedef struct
     int            label   = -1;
     float          quality = 0.0;
     std::bitset<8> flags   = 0x00;
-}
-Vert_std_attributes;
+};
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-typedef struct
+struct Edge_std_attributes
 {
     Color          color = Color::BLACK();
     int            label = -1;
     std::bitset<8> flags = 0x00;
-}
-Edge_std_attributes;
+};
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-typedef struct
+struct Polygon_std_attributes
 {
     vec3d          normal  = vec3d(0,0,0);
     Color          color   = Color::WHITE();
@@ -163,19 +160,17 @@ typedef struct
     float          quality = 0.0;
     float          AO      = 1.0;
     std::bitset<8> flags   = 0x00;
-}
-Polygon_std_attributes;
+};
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-typedef struct
+struct Polyhedron_std_attributes
 {
     Color          color   = Color::WHITE();
     int            label   = -1;
     float          quality = 0.0;
     std::bitset<8> flags   = 0x00;
-}
-Polyhedron_std_attributes;
+};
 
 }
 


### PR DESCRIPTION
Fixes two separate small issues:
1. An implicit conversion in std::iota caused a warning on high warning levels (therefore an error when building with /WX)
2. C-style typedefs of anonymous structs in `mesh_attributes` results in a hard error with `/permissive-`.

On an unrelated note, the definition for `uint` should be a typedef, not a macro, otherwise it can wreak havoc throughout the user's code if they happen to use that name (which was true in mine). I didn't attempt this fix because the scope of the impact is undoubtedly rather large, but since I assume your `uint` is coming from [`<types.h>`](https://github.com/torvalds/linux/blob/master/include/linux/types.h) on linux there's no reason why you can't do this somewhere:
```cpp
namespace cinolib
{
#ifdef __linux__
	using ::uint;
#else 
	using uint = unsigned int;
#endif
}
```
