### PR TITLE
fix drawable hexmesh

### DIFF
--- a/include/cinolib/meshes/drawable_hexmesh.h
+++ b/include/cinolib/meshes/drawable_hexmesh.h
@@ -69,14 +69,14 @@ class DrawableHexmesh : public AbstractDrawablePolyhedralMesh<Hexmesh<M,V,E,F,P>
 
         //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        // explicit DrawableHexmesh(const std::vector<vec3d>             & verts,
-        //                          const std::vector<std::vector<uint>> & faces,
-        //                          const std::vector<std::vector<uint>> & polys,
-        //                          const std::vector<std::vector<bool>> & polys_face_winding)
-        // : Hexmesh<M,V,E,F,P>(verts, faces, polys, polys_face_winding)
-        // {
-        //     this->init_drawable_stuff();
-        // }
+        explicit DrawableHexmesh(const std::vector<vec3d>             & verts,
+                                 const std::vector<std::vector<uint>> & faces,
+                                 const std::vector<std::vector<uint>> & polys,
+                                 const std::vector<std::vector<bool>> & polys_face_winding)
+        : Hexmesh<M,V,E,F,P>(verts, faces, polys, polys_face_winding)
+        {
+            this->init_drawable_stuff();
+        }
 
         //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/include/cinolib/meshes/drawable_hexmesh.h
+++ b/include/cinolib/meshes/drawable_hexmesh.h
@@ -69,14 +69,14 @@ class DrawableHexmesh : public AbstractDrawablePolyhedralMesh<Hexmesh<M,V,E,F,P>
 
         //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        explicit DrawableHexmesh(const std::vector<vec3d>             & verts,
-                                 const std::vector<std::vector<uint>> & faces,
-                                 const std::vector<std::vector<uint>> & polys,
-                                 const std::vector<std::vector<bool>> & polys_face_winding)
-        : Hexmesh<M,V,E,F,P>(verts, faces, polys, polys_face_winding)
-        {
-            this->init_drawable_stuff();
-        }
+        // explicit DrawableHexmesh(const std::vector<vec3d>             & verts,
+        //                          const std::vector<std::vector<uint>> & faces,
+        //                          const std::vector<std::vector<uint>> & polys,
+        //                          const std::vector<std::vector<bool>> & polys_face_winding)
+        // : Hexmesh<M,V,E,F,P>(verts, faces, polys, polys_face_winding)
+        // {
+        //     this->init_drawable_stuff();
+        // }
 
         //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -92,6 +92,15 @@ class DrawableHexmesh : public AbstractDrawablePolyhedralMesh<Hexmesh<M,V,E,F,P>
         explicit DrawableHexmesh(const std::vector<double> & coords,
                                  const std::vector<uint>   & polys)
         : Hexmesh<M,V,E,F,P>(coords, polys)
+        {
+            this->init_drawable_stuff();
+        }
+
+        //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        explicit DrawableHexmesh(const std::vector<vec3d>             & verts,
+                                 const std::vector<std::vector<uint>> & polys)
+        : Hexmesh<M,V,E,F,P>(verts, polys)
         {
             this->init_drawable_stuff();
         }


### PR DESCRIPTION
Added a constructor that is defined in _Hexmesh_ but not in _DrawableHexmesh_ : 
`DrawableHexmesh(const std::vector<vec3d> & verts,  const std::vector<std::vector<uint>> & polys)`

Conversely, the constructor that is not defined in _Hexmesh_ but is in _DrawableHexmesh_ has been commented out.