### PR TITLE
bug fix

### DIFF
--- a/include/cinolib/padding.cpp
+++ b/include/cinolib/padding.cpp
@@ -54,7 +54,8 @@ void padding(AbstractPolyhedralMesh<M,V,E,F,P> & m, const bool inwards)
     {
         if(m.vert_is_on_srf(vid))
         {
-            uint  new_vid = m.vert_add(m.vert(vid));       // update position;
+			vec3d pos_to_add = m.vert(vid);
+            uint  new_vid = m.vert_add(pos_to_add);       // update position;
             vec3d off     = m.vert_data(vid).normal*l*0.5;
             if(inwards) m.vert(  vid  ) -= off;
             else        m.vert(new_vid) += off;


### PR DESCRIPTION
Using reference passing here would lead to a very high risk of causing the program to crash or exhibit undefined behavior when repeatedly using the padding function. Therefore, it is recommended to create a copy before calling the function vert_add.