### PR TITLE
Add function "hexSheet"

### DIFF
--- a/include/cinolib/meshes/hexmesh.cpp
+++ b/include/cinolib/meshes/hexmesh.cpp
@@ -317,6 +317,47 @@ std::vector<uint> Hexmesh<M,V,E,F,P>::face_sheet(const uint fid) const
 
 template<class M, class V, class E, class F, class P>
 CINO_INLINE
+std::unordered_set<uint> Hexmesh<M, V, E, F, P>::hex_sheet(const uint eid) const
+{
+    std::unordered_set<uint> visitedEids;
+    std::unordered_set<uint> visitedPids;
+    std::queue<uint> toVisitEids;
+    toVisitEids.push(eid);
+    visitedEids.insert(eid);
+    while (!toVisitEids.empty())
+    {
+        const uint currEid{ toVisitEids.front() };
+        toVisitEids.pop();
+        for (const uint adjPid : this->adj_e2p(currEid))
+        {
+            if (!visitedPids.contains(adjPid))
+            {
+                visitedPids.insert(adjPid);
+            }
+        }
+        for (const uint adjFid : this->adj_e2f(currEid))
+        {
+            for (const uint fidEid : this->adj_f2e(adjFid))
+            {
+                if (fidEid != currEid && !this->edges_are_adjacent(currEid, fidEid))
+                {
+                    if (!visitedEids.contains(fidEid))
+                    {
+                        visitedEids.insert(fidEid);
+                        toVisitEids.push(fidEid);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    return visitedPids;
+}
+
+//::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+template<class M, class V, class E, class F, class P>
+CINO_INLINE
 vec3d Hexmesh<M,V,E,F,P>::verts_average(const std::vector<uint> & vids) const
 {
     vec3d res(0,0,0);

--- a/include/cinolib/meshes/hexmesh.h
+++ b/include/cinolib/meshes/hexmesh.h
@@ -109,6 +109,7 @@ class Hexmesh : public AbstractPolyhedralMesh<M,V,E,F,P>
         //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         std::vector<uint> face_sheet(const uint fid) const; // stop at singular edges
+        std::unordered_set<uint> hex_sheet(const uint eid) const;
 
         //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This pull request introduces a new method, hex_sheet(const uint eid), to the Hexmesh class. This function identifies and returns a set of all hexahedron IDs that form a continuous sheet connected through face-opposite edge relationships, starting from a given edge.
<img width="842" height="712" alt="image" src="https://github.com/user-attachments/assets/a7d1f005-4717-4f30-8c26-46aedf23f36b" />
<img width="596" height="533" alt="image" src="https://github.com/user-attachments/assets/a2b11f75-67b2-47ca-a3f2-244977307b6e" />
<img width="1532" height="704" alt="image" src="https://github.com/user-attachments/assets/fcb66cce-9507-4f71-abc5-6c4275a6d667" />
