### PR TITLE
Add n_threads_hint overload to PARALLEL_FOR

### DIFF
--- a/include/cinolib/parallel_for.cpp
+++ b/include/cinolib/parallel_for.cpp
@@ -61,6 +61,34 @@ static void PARALLEL_FOR(      uint   beg,
         // estimate number of threads in the pool
         const static unsigned n_threads_hint = std::thread::hardware_concurrency();
         const static unsigned n_threads      = (n_threads_hint==0u) ? 8u : n_threads_hint;
+        // parallelize the loop
+        PARALLEL_FOR(beg, end, serial_if_less_than, n_threads, func);
+    }
+#else
+    for(uint i=beg; i<end; ++i) func(i);
+#endif
+}
+
+template<typename Func>
+CINO_INLINE
+static void PARALLEL_FOR(      uint   beg,
+                               uint   end,
+                         const uint   serial_if_less_than,
+                         const uint   n_threads_hint,
+                         const Func & func)
+{
+#ifndef SERIALIZE_PARALLEL_FOR
+
+    uint n = end - beg + 1;
+
+    if(n<serial_if_less_than)
+    {
+        for(uint i=beg; i<end; ++i) func(i);
+    }
+    else
+    {
+        // estimate number of threads in the pool
+        const static unsigned n_threads      = (n_threads_hint==0u) ? 8u : n_threads_hint;
 
         // split the full range into sub ranges of equal size
         uint slice = (uint)std::round(n/static_cast<double>(n_threads));

--- a/include/cinolib/parallel_for.h
+++ b/include/cinolib/parallel_for.h
@@ -85,6 +85,14 @@ static void PARALLEL_FOR(      uint   beg,
                                uint   end,
                          const uint   serial_if_less_than,
                          const Func & func);
+
+template<typename Func>
+CINO_INLINE
+static void PARALLEL_FOR(      uint   beg,
+                               uint   end,
+                         const uint   serial_if_less_than,
+                         const uint   n_threads_hint,
+                         const Func & func);
 }
 
 #ifndef  CINO_STATIC_LIB


### PR DESCRIPTION
Introduce a new PARALLEL_FOR overload that accepts an n_threads_hint so callers can specify the desired thread pool size. The original PARALLEL_FOR now delegates to this overload. Behavior is preserved: small ranges (below serial_if_less_than) are executed serially; otherwise the work is split across threads. The implementation uses n_threads_hint (or falls back to std::thread::hardware_concurrency()/8) and the new function is declared in the header.